### PR TITLE
Add action for automation build binaries and release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
+          cache: false
 
       - name: Run go mod tidy
         run: go mod tidy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
 
       - name: Build binary
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
       - name: Download binaries
         uses: actions/download-artifact@v4
         with:
-          name: SNI-Finder-*
-          path: .
+          pattern: SNI-Finder-*
+          merge-multiple: true
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           go-version: '1.21'
 
+      - name: Run go mod tidy
+        run: go mod tidy
+
       - name: Build binary
         env:
           GOARCH: ${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,28 @@ jobs:
       - name: Run go mod tidy
         run: go mod tidy
 
+      - name: Set environment variables
+        run: |
+          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
+            echo "GOOS=linux" >> $GITHUB_ENV
+          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
+            echo "GOOS=darwin" >> $GITHUB_ENV
+          else
+            echo "GOOS=windows" >> $GITHUB_ENV
+          fi
+
       - name: Build binary
         env:
           GOARCH: ${{ matrix.arch }}
-          GOOS: ${{ matrix.os == 'ubuntu-latest' && 'linux' || matrix.os == 'macos-latest' && 'darwin' || 'windows' }}
+          GOOS: ${{ env.GOOS }}
         run: |
-          go build -o SNI-Finder-${{ matrix.os }}-${{ matrix.arch }} .
+          go build -o SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }} .
 
       - name: Upload binaries
         uses: actions/upload-artifact@v3
         with:
-          name: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
-          path: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+          name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
+          path: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
 
   release:
     name: Create GitHub Release
@@ -49,7 +59,7 @@ jobs:
       - name: Download binaries
         uses: actions/download-artifact@v3
         with:
-          name: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+          name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
           path: .
 
       - name: Create Release
@@ -69,6 +79,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
-          asset_name: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+          asset_path: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
+          asset_name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - '*'
 
 env:
-  REGISTRY_IMAGE: vladkmrdnv/water_level_of_the_oka_river_bot
   BIN_PATH: /tmp/bin
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Download binaries
         uses: actions/download-artifact@v3
         with:
-          name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
+          name: SNI-Finder-*
           path: .
 
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*'
 
+env:
+  REGISTRY_IMAGE: vladkmrdnv/water_level_of_the_oka_river_bot
+  BIN_PATH: /tmp/bin
+
 jobs:
   build:
     name: Build binaries
@@ -59,29 +63,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Create bin directory
+        run: |
+          mkdir -p ${{ env.BIN_PATH }}
+
       - name: Download binaries
         uses: actions/download-artifact@v4
         with:
+          path: ${{ env.BIN_PATH }}
           pattern: SNI-Finder-*
           merge-multiple: true
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
+      - name: Display structure of downloaded files
+        run: ls -R ${{ env.BIN_PATH }}
 
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release with assets
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: SNI-Finder-${{ matrix.os == 'ubuntu-latest' && 'linux' || matrix.os == 'macos-latest' && 'darwin' || 'windows' }}-${{ matrix.arch }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
-          asset_name: SNI-Finder-${{ matrix.os == 'ubuntu-latest' && 'linux' || matrix.os == 'macos-latest' && 'darwin' || 'windows' }}-${{ matrix.arch }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
-          asset_content_type: application/octet-stream
+          files: ${{ env.BIN_PATH }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
 
@@ -45,7 +45,7 @@ jobs:
           go build -o SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }} .
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
           path: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Download binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: SNI-Finder-*
           path: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,71 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [amd64, arm64]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+
+      - name: Build binary
+        env:
+          GOARCH: ${{ matrix.arch }}
+          GOOS: ${{ matrix.os == 'ubuntu-latest' && 'linux' || matrix.os == 'macos-latest' && 'darwin' || 'windows' }}
+        run: |
+          go build -o SNI-Finder-${{ matrix.os }}-${{ matrix.arch }} .
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+          path: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+          path: .
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+          asset_name: SNI-Finder-${{ matrix.os }}-${{ matrix.arch }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,20 +35,22 @@ jobs:
             echo "GOOS=darwin" >> $GITHUB_ENV
           else
             echo "GOOS=windows" >> $GITHUB_ENV
+            echo "EXT=.exe" >> $GITHUB_ENV
           fi
 
       - name: Build binary
         env:
           GOARCH: ${{ matrix.arch }}
           GOOS: ${{ env.GOOS }}
+          EXT: ${{ env.EXT }}
         run: |
-          go build -o SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }} .
+          go build -o SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}${{ env.EXT }} .
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
-          name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
-          path: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
+          name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}${{ env.EXT }}
+          path: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}${{ env.EXT }}
 
   release:
     name: Create GitHub Release
@@ -79,6 +81,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
-          asset_name: SNI-Finder-${{ env.GOOS }}-${{ matrix.arch }}
+          asset_path: SNI-Finder-${{ matrix.os == 'ubuntu-latest' && 'linux' || matrix.os == 'macos-latest' && 'darwin' || 'windows' }}-${{ matrix.arch }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+          asset_name: SNI-Finder-${{ matrix.os == 'ubuntu-latest' && 'linux' || matrix.os == 'macos-latest' && 'darwin' || 'windows' }}-${{ matrix.arch }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}
           asset_content_type: application/octet-stream

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ It is recommended to run this scanner locally _(with your residential internet)_
 
 ## Run
 
-### Linux:
+### Linux/Mac OS:
+
+Be careful when choosing an architecture, all binaries are available in two versions - `amd64` and `arm64`.
 
 1.
     ```
-    wget "https://github.com/hawshemi/SNI-Finder/releases/latest/download/SNI-Finder-linux-amd64" -O SNI-Finder && chmod +x SNI-Finder
+    wget "https://github.com/hawshemi/SNI-Finder/releases/latest/download/SNI-Finder-$(uname -s | tr A-Z a-z)-amd64" -O SNI-Finder && chmod +x SNI-Finder
     ```
 2. 
     ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/v-kamerdinerov/SNI-Finder
+module github.com/hawshemi/SNI-Finder
 
 go 1.21.3
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hawshemi/SNI-Finder
+module github.com/v-kamerdinerov/SNI-Finder
 
 go 1.21.3
 


### PR DESCRIPTION
Added automatic build and release from tag.

Also slightly edited README a bit, added information about running on different architectures and on Mac OS.

Build for all possible OS variations and architectures.

```
SNI-Finder-darwin-amd64
SNI-Finder-darwin-arm64
SNI-Finder-linux-amd64
SNI-Finder-linux-arm64
SNI-Finder-windows-amd64.exe
SNI-Finder-windows-arm64.exe
```

The release process is trivial:
- create a new tag in the console
```
❯ git tag 1.0.7
```

- push tags
```
❯ git push origin --tags
Warning: Permanently added 'github.com' (ED25519) to the list of known hosts.
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To github.com:v-kamerdinerov/SNI-Finder.git
 * [new tag] 1.0.7 -> 1.0.7
```

- enjoy automatic binary build and release

<img width="644" alt="image" src="https://github.com/user-attachments/assets/b9cf364c-7244-40f1-9590-a54617420598">
<img width="677" alt="image" src="https://github.com/user-attachments/assets/5cb07756-4d4d-4028-bbc3-e26adb06808b">
<img width="1149" alt="image" src="https://github.com/user-attachments/assets/4a6be244-ae82-4fe5-9411-56fd6dd9cfe4">


For maintainer - please squash all my commits :) Sorry for debugging process.